### PR TITLE
Moto 2.X support

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,10 +2,10 @@
 CHANGELOG
 =========
 
-1.5.1 (unreleased)
+1.6.0 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Upgraded to latest pkgs including moto 2.0.5, added py3.9
 
 
 1.5.0 (2020-12-01)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,11 @@
 # shoobx.mocks3
 -e . [test]
 
-coverage == 5.3
+coverage == 5.5
 freezegun == 1.0.0
 junit-xml == 1.9
-mock == 4.0.2
-moto == 1.3.16
+mock == 4.0.3
+moto == 2.0.5
 python-subunit == 1.4.0
-zope.testrunner == 5.2
+zope.testrunner == 5.3.0
+boto >= 2.49.0

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Natural Language :: English',

--- a/src/shoobx/mocks3/models.py
+++ b/src/shoobx/mocks3/models.py
@@ -91,8 +91,17 @@ class Key(models.FakeKey):
     expiry_date = _InfoProperty('expiry_date')
     acl = _AclProperty('acl')
 
-    def __init__(self, bucket, name, version=0, is_versioned=False,
-                 multipart=None, bucket_name=None):
+    def __init__(self,
+                 bucket,
+                 name,
+                 version = 0,
+                 is_versioned = False,
+                 multipart = None,
+                 bucket_name=None,
+                 encryption = None,
+                 kms_key_id = None,
+                 bucket_key_enabled = None
+                 ):
         self.bucket = bucket
         self.name = name
         self.version = version
@@ -103,6 +112,9 @@ class Key(models.FakeKey):
         self._info_path = os.path.join(self._versioned_path, 'info.json')
         self._value_path = os.path.join(self._versioned_path, 'value')
         self.bucket_name = bucket_name
+        self.encryption = encryption
+        self.kms_key_id = kms_key_id
+        self.bucket_key_enabled = bucket_key_enabled
 
     @property
     def _version_id(self):
@@ -609,8 +621,17 @@ class ShoobxS3Backend(models.S3Backend):
         bucket = Bucket(self, bucket_name)
         return bucket.delete()
 
-    def set_object(self, bucket_name, key_name, value, storage=None, etag=None,
-                   multipart=None):
+    def set_object(self,
+                   bucket_name,
+                   key_name,
+                   value,
+                   storage=None,
+                   etag=None,
+                   multipart=None,
+                   encryption=None,
+                   kms_key_id=None,
+                   bucket_key_enabled=None,
+                   ):
         key_name = models.clean_key_name(key_name)
 
         bucket = self.get_bucket(bucket_name)
@@ -626,7 +647,10 @@ class ShoobxS3Backend(models.S3Backend):
             key_name,
             version = new_version,
             is_versioned=bucket.is_versioned,
-            multipart=multipart
+            multipart=multipart,
+            encryption=encryption,
+            kms_key_id=kms_key_id,
+            bucket_key_enabled=bucket_key_enabled,
         )
         new_key.create(
             value=value,


### PR DESCRIPTION
Still supports boto (test_s3.py), so maybe we should drop boto support which is now replaced by boto3.

If that is the case we can either drop test_s3.py or migrate to test_s3_boto3.py if there is something worth keeping.

That would allow dropping boto from requirements which is not pulled by other reqs any more but had to be included explicitly.