### PR TITLE
Fix API change in 3.0.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,16 +2,16 @@
 CHANGELOG
 =========
 
-2.1.1 (unreleased)
+3.0.0 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Compatibility with moto 3.0.0
 
 
 2.1.0 (2022-01-21)
 ------------------
 
-- Compatibility with moto 3.2.0
+- Compatibility with moto 2.3.2
 
 - Fix tox config, dropping Py2.7 and PyPy, adding Py3.10.
 

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ help:
 
 .PHONY: clean
 clean:
-	rm -rf ve/ pip-selfcheck.json
+	rm -rf ve/ pip-selfcheck.json .tox/
 
 .PHONY: real-clean
 real-clean:

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,8 +5,7 @@ coverage == 5.5
 freezegun == 1.0.0
 junit-xml == 1.9
 mock == 4.0.3
-moto == 2.3.2
+moto == 3.0.0
 python-subunit == 1.4.0
-responses == 0.16.0
 tox == 3.24.5
 zope.testrunner == 5.3.0

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
     ],
     install_requires=[
         'boto3',
-        'moto[server]',
+        'moto[server]>=3.0.0',
         'flask_cors',
     ],
     extras_require=dict(

--- a/src/shoobx/mocks3/urls.py
+++ b/src/shoobx/mocks3/urls.py
@@ -36,5 +36,5 @@ url_paths = {
 
     # path-based bucket + key
     '{0}/(?P<bucket_name_path>[^/]+)/(?P<key_name>.+)':
-        S3ResponseInstance.key_or_control_response,
+        S3ResponseInstance.key_response,
 }


### PR DESCRIPTION
`key_or_control_response` was changed to `key_response`