### PR TITLE
Add config to allow env vars import

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,7 @@ setup(
         'moto[server]>=3.0.0',
         'flask_cors',
         'pytz',
+        'pydantic-settings'
     ],
     extras_require=dict(
         test=[

--- a/src/shoobx/mocks3/run.py
+++ b/src/shoobx/mocks3/run.py
@@ -63,12 +63,11 @@ def serve(argv=sys.argv[1:]):
 
     # Start the server.
     conf = config.load_config(args.config_file)
-    host = conf.get("shoobx:server", "host-ip")
-    port = int(conf.get("shoobx:server", "host-port"))
+
     app.run(
-        host=host,
-        port=port,
+        host=conf.server.host_ip,
+        port=conf.server.host_port,
         request_handler=ShoobxRequestHandler,
-        use_reloader=conf.getboolean("shoobx:mocks3", "reload"),
-        use_debugger=conf.getboolean("shoobx:mocks3", "debug"),
+        use_reloader=conf.mocks3.reload,
+        use_debugger=conf.mocks3.debug,
     )


### PR DESCRIPTION
Config priority order:
`default -> env -> config file`

Its need to make mocks3 configurable outside. In my case with env from `docker-compose`

Related PR: https://github.com/Shoobx/shoobx.mocks3/pull/20