### PR TITLE
Fix container name

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,5 +37,5 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           push: true
-          tags: ghcr.io/Shoobx/shoobx.mocks3:${{ github.ref_name }}, ghcr.io/Shoobx/shoobx.mocks3:latest
+          tags: ghcr.io/shoobx/shoobx.mocks3:${{ github.ref_name }}, ghcr.io/shoobx/shoobx.mocks3:latest
           platforms: ${{ env.TARGET_PLATFORMS }}


### PR DESCRIPTION
Fix for: `Error: buildx failed with: ERROR: invalid tag "ghcr.io/Shoobx/shoobx.mocks3:4.2.5.1": repository name must be lowercase`